### PR TITLE
Add Sundale's quest framework as an example

### DIFF
--- a/examples/sundale.js
+++ b/examples/sundale.js
@@ -1,0 +1,121 @@
+// An example of how scripting can be used to manipulate quests, as well as how messages and the state variable can be used to store and show information
+// The code can be given basic changes using the state.configuration object, without needing to deal with the rest of the code
+// The scenario this was made for can be seen at https://play.aidungeon.io/scenario/71bab1a0-9d70-11ea-8733-c15678a0b129
+
+// INPUT MODIFIER
+
+const modifier = (text) => {
+    state.configuration = {
+        enableSelectionOnCompletedQuest: false, // Whether quest selection should be restricted until a specific quest is completed
+        enableSelectionOnQuest: 0, // The line number of the quest in the list of quests (e.g. quest on second line = 2). Only used when the above is true.
+        quests: [ // The quests that will become available to the player either after the above quest is completed or at the start of the scenario.
+            {
+                name: "quit your job", // The quest's name, shown in the selection message
+                objectives: ["resign from your job"], // The objectives that are part of the quest
+                nextQuests: [ // The quests that should be assigned after the player completes this one
+                    {
+                        name: "find a new job",
+                        objectives: ["get a job"],
+                        nextQuests: []
+                    }
+                ]
+            }
+        ]
+    }
+
+    if (state.initialised != true) {
+        state.finishedScenario = false
+        state.initialised = true
+        if (!state.configuration.enableSelectionOnCompletedQuest) {
+            state.availableQuests = JSON.parse(JSON.stringify(state.configuration.quests))
+        } else {
+            state.availableQuests = []
+        }
+        state.assignedQuest = ""
+        state.nextOutput = ""
+    }
+
+    state.nextOutput = ""
+
+    if (text.toLowerCase().startsWith("\n> you take up quest ")) {
+        state.assignedQuest = JSON.parse(JSON.stringify(state.availableQuests[text.toLowerCase().substring(21) - 1]))
+        quests.push({
+            quest: state.assignedQuest.objectives.shift()
+        })
+        state.nextOutput = "You decide that the next thing you want to do with your life is " + state.assignedQuest.name.toLowerCase() + "."
+    } else if (text.toLowerCase().includes("\n> you give up on your quest.")) {
+        state.nextOutput = "You give up on your quest to " + state.assignedQuest.name.toLowerCase() + "."
+        state.assignedQuest = ""
+        quests.splice(3)
+    }
+
+    return {
+        text: text
+    }
+}
+
+modifier(text)
+
+
+// OUTPUT MODIFIER
+
+const modifier = (text) => {
+
+    let modifiedText = text
+
+    if (!state.finishedScenario || !state.configuration.enableSelectionOnCompletedQuest) state.message = ""
+
+    if ((state.finishedScenario || !state.configuration.enableSelectionOnCompletedQuest) && state.assignedQuest == "") {
+        questNames = []
+        for (quest of state.availableQuests) {
+            questNames.push(quest.name)
+        }
+        state.message = "Available Quests: " + questNames.join(", ") + ". To take up a quest, type 'take up quest <quest number in list>'."
+    } else if (state.assignedQuest != "") {
+        if (!quests[3].completed) {
+            state.message = "Current Objective: " + quests[3].quest + ". To quit, type 'give up on my quest'."
+        } else {
+            nextObjective = state.assignedQuest.objectives.shift()
+            if (nextObjective == undefined) {
+                quests.splice(3)
+                state.availableQuests = state.availableQuests.filter(e => e.name !== state.assignedQuest.name)
+                for (nextQuest of state.assignedQuest.nextQuests) {
+                    state.availableQuests.push(nextQuest)
+                }
+                state.assignedQuest = ""
+                questNames = []
+                for (quest of state.availableQuests) {
+                    questNames.push(quest.name)
+                }
+                state.message = "Available Quests: " + questNames.join(", ") + ". To take up a quest, type 'take up quest <quest number in list>'."
+            } else {
+                quests.splice(3)
+                quests.push({
+                    quest: nextObjective
+                })
+                state.message = "Objective completed! New objective: " + quests[3].quest + ". To quit, type 'give up on my quest'."
+            }
+        }
+    }
+
+    if (state.configuration.enableSelectionOnCompletedQuest) {
+        if (quests[state.configuration.enableSelectionOnQuest - 1].completed == true && !state.finishedScenario) {
+            state.message = "Quests have been assigned and will be accessible next turn."
+            state.finishedScenario = true
+            state.availableQuests = JSON.parse(JSON.stringify(state.configuration.quests))
+        }
+    }
+
+
+    if (state.nextOutput !== "") {
+        return {
+            text: state.nextOutput
+        }
+    }
+
+    return {
+        text: modifiedText
+    };
+}
+
+modifier(text)

--- a/examples/sundale.js
+++ b/examples/sundale.js
@@ -7,7 +7,8 @@
 const modifier = (text) => {
     state.configuration = {
         enableSelectionOnCompletedQuest: false, // Whether quest selection should be restricted until a specific quest is completed
-        enableSelectionOnQuest: 0, // The line number of the quest in the list of quests (e.g. quest on second line = 2). Only used when the above is true.
+        enableSelectionOnQuest: 0, // The line number of the quest in the list of quests (e.g. quest on second line = 2) on the Edit Scenario page. Only used when the above is true.
+        initialQuests: 0, // The amount of quests inputted into the Edit Scenario page
         quests: [ // The quests that will become available to the player either after the above quest is completed or at the start of the scenario.
             {
                 name: "quit your job", // The quest's name, shown in the selection message
@@ -46,7 +47,7 @@ const modifier = (text) => {
     } else if (text.toLowerCase().includes("\n> you give up on your quest.")) {
         state.nextOutput = "You give up on your quest to " + state.assignedQuest.name.toLowerCase() + "."
         state.assignedQuest = ""
-        quests.splice(3)
+        quests.splice(state.configuration.initialQuests)
     }
 
     return {
@@ -72,12 +73,12 @@ const modifier = (text) => {
         }
         state.message = "Available Quests: " + questNames.join(", ") + ". To take up a quest, type 'take up quest <quest number in list>'."
     } else if (state.assignedQuest != "") {
-        if (!quests[3].completed) {
-            state.message = "Current Objective: " + quests[3].quest + ". To quit, type 'give up on my quest'."
+        if (!quests[state.configuration.initialQuests].completed) {
+            state.message = "Current Objective: " + quests[state.configuration.initialQuests].quest + ". To quit, type 'give up on my quest'."
         } else {
             nextObjective = state.assignedQuest.objectives.shift()
             if (nextObjective == undefined) {
-                quests.splice(3)
+                quests.splice(state.configuration.initialQuests)
                 state.availableQuests = state.availableQuests.filter(e => e.name !== state.assignedQuest.name)
                 for (nextQuest of state.assignedQuest.nextQuests) {
                     state.availableQuests.push(nextQuest)
@@ -89,11 +90,11 @@ const modifier = (text) => {
                 }
                 state.message = "Available Quests: " + questNames.join(", ") + ". To take up a quest, type 'take up quest <quest number in list>'."
             } else {
-                quests.splice(3)
+                quests.splice(state.configuration.initialQuests)
                 quests.push({
                     quest: nextObjective
                 })
-                state.message = "Objective completed! New objective: " + quests[3].quest + ". To quit, type 'give up on my quest'."
+                state.message = "Objective completed! New objective: " + quests[state.configuration.initialQuests].quest + ". To quit, type 'give up on my quest'."
             }
         }
     }


### PR DESCRIPTION
Sundale's quest framework is a good example of how scripting can be used to manipulate quests, as well as showing how state and messages can be used to store and show information. Currently, the `quests` variable isn't explained in any of the examples, so this might help with that too.

P.S. What happened to `utils.checkQuestCompleted`? It would be cool to have a function that allows the state of the game to be compared with source text at will, rather than having to constantly swap out the current quest.